### PR TITLE
workspace paths fixed for one level up

### DIFF
--- a/exampleEmpty/vscode_oF.code-workspace
+++ b/exampleEmpty/vscode_oF.code-workspace
@@ -4,10 +4,10 @@
 			"path": "."
 		},
 		{
-			"path": "${workspaceRoot}/../../../../libs/openFrameworks"
+			"path": "${workspaceRoot}/../../../../../libs/openFrameworks"
 		},
 		{
-			"path": "${workspaceRoot}/../../../../addons"
+			"path": "${workspaceRoot}/../../../../../addons"
 		}
 	],
 	"settings": {}


### PR DESCRIPTION
This seems sensible to me, now that the "exampleEmpty" project folder has been moved one level up?